### PR TITLE
Fixed package type to metapackage.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "multisafepay/magento2-catalog-inventory": "1.0.2",
         "multisafepay/magento2-msi": "1.0.1"
     },
-    "type": "library",
+    "type": "metapackage",
     "license": [
         "OSL-3.0"
     ]


### PR DESCRIPTION
Hi!

If it's metapackage - it's should be set to another type. In this case it shouldn't write anything to filesystem and shouldn't add additional folder with files that irrelevant for packages.

Please review,  